### PR TITLE
Refactor exception classes to correctly set the name property for better clarity in error messages

### DIFF
--- a/src/io/src/exceptions/directory-exists.exception.ts
+++ b/src/io/src/exceptions/directory-exists.exception.ts
@@ -11,6 +11,6 @@ import { Exception } from "@contextjs/system";
 export class DirectoryExistsException extends Exception {
     public constructor(directory: string) {
         super(`The specified directory already exists: ${directory}`);
-        this.name = Exception.name;
+        this.name = DirectoryExistsException.name;
     }
 }

--- a/src/io/src/exceptions/file-exists.exception.ts
+++ b/src/io/src/exceptions/file-exists.exception.ts
@@ -11,6 +11,6 @@ import { Exception } from "@contextjs/system";
 export class FileExistsException extends Exception {
     public constructor(file: string) {
         super(`The specified file already exists: ${file}`);
-        this.name = Exception.name;
+        this.name = FileExistsException.name;
     }
 }

--- a/src/io/src/exceptions/file-not-found.exception.ts
+++ b/src/io/src/exceptions/file-not-found.exception.ts
@@ -11,6 +11,6 @@ import { Exception } from "@contextjs/system";
 export class FileNotFoundException extends Exception {
     public constructor(file: string) {
         super(`The specified file was not found: ${file}`);
-        this.name = Exception.name;
+        this.name = FileNotFoundException.name;
     }
 }

--- a/src/io/src/exceptions/path-not-found.exception.ts
+++ b/src/io/src/exceptions/path-not-found.exception.ts
@@ -11,6 +11,6 @@ import { Exception } from "@contextjs/system";
 export class PathNotFoundException extends Exception {
     public constructor(path: string) {
         super(`The specified path was not found: ${path}`);
-        this.name = Exception.name;
+        this.name = PathNotFoundException.name;
     }
 }

--- a/src/io/tests/exceptions/directory-exists.exception.test.ts
+++ b/src/io/tests/exceptions/directory-exists.exception.test.ts
@@ -21,5 +21,5 @@ test('DirectoryExistsException: message - success', (context: TestContext) => {
 
 test('DirectoryExistsException: toString - success', (context: TestContext) => {
     const exception = new DirectoryExistsException("directory");
-    context.assert.strictEqual(exception.toString(), "Exception: The specified directory already exists: directory");
+    context.assert.strictEqual(exception.toString(), "DirectoryExistsException: The specified directory already exists: directory");
 });

--- a/src/io/tests/exceptions/file-exists.exception.test.ts
+++ b/src/io/tests/exceptions/file-exists.exception.test.ts
@@ -21,5 +21,5 @@ test('FileExistsException: message - success', (context: TestContext) => {
 
 test('FileExistsException: toString - success', (context: TestContext) => {
     const exception = new FileExistsException("file");
-    context.assert.strictEqual(exception.toString(), "Exception: The specified file already exists: file");
+    context.assert.strictEqual(exception.toString(), "FileExistsException: The specified file already exists: file");
 });

--- a/src/io/tests/exceptions/file-not-found.exception.test.ts
+++ b/src/io/tests/exceptions/file-not-found.exception.test.ts
@@ -21,5 +21,5 @@ test('FileNotFoundException: message - success', (context: TestContext) => {
 
 test('FileNotFoundException: toString - success', (context: TestContext) => {
     const exception = new FileNotFoundException("file");
-    context.assert.strictEqual(exception.toString(), "Exception: The specified file was not found: file");
+    context.assert.strictEqual(exception.toString(), "FileNotFoundException: The specified file was not found: file");
 });

--- a/src/io/tests/exceptions/path-not-found.exception.test.ts
+++ b/src/io/tests/exceptions/path-not-found.exception.test.ts
@@ -21,5 +21,5 @@ test('PathNotFoundException: message - success', (context: TestContext) => {
 
 test('PathNotFoundException: toString - success', (context: TestContext) => {
     const exception = new PathNotFoundException("path");
-    context.assert.strictEqual(exception.toString(), "Exception: The specified path was not found: path");
+    context.assert.strictEqual(exception.toString(), "PathNotFoundException: The specified path was not found: path");
 });

--- a/src/system/src/exceptions/null-reference.exception.ts
+++ b/src/system/src/exceptions/null-reference.exception.ts
@@ -11,6 +11,6 @@ import { Exception } from "./exception.js";
 export class NullReferenceException extends Exception {
     public constructor() {
         super('The specified reference is null or undefined.');
-        this.name = Exception.name;
+        this.name = NullReferenceException.name;
     }
 }

--- a/src/system/tests/exceptions/null-reference.exception.test.ts
+++ b/src/system/tests/exceptions/null-reference.exception.test.ts
@@ -24,5 +24,5 @@ test('NullReferenceException: message - success', (context: TestContext) => {
 
 test('NullReferenceException: toString - success', (context: TestContext) => {
     const exception = new NullReferenceException();
-    context.assert.strictEqual(exception.toString(), "Exception: The specified reference is null or undefined.");
+    context.assert.strictEqual(exception.toString(), "NullReferenceException: The specified reference is null or undefined.");
 });


### PR DESCRIPTION
Refactor exception classes to correctly set the name property for better clarity in error messages