### PR TITLE
feat: Refactor command type tests and add command type extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Packages  
 
-**[@contextjs/context](https://github.com/contextjs/context/tree/main/src/context)**: The base package for creating, building, and debugging projects.
+**[@contextjs/context](https://github.com/contextjs/context/tree/main/src/context)**: Official CLI for building and managing ContextJS projects.
 
 - **[@contextjs/collections](https://github.com/contextjs/context/tree/main/src/collections)**: File system utilities for reading, writing, and inspecting files, directories, and paths — with clean APIs and exception-based error handling.
 - **[@contextjs/compiler](https://github.com/contextjs/context/tree/main/src/compiler)**: TypeScript compiler with extensibility support for internal and external transformers.

--- a/src/context/README.md
+++ b/src/context/README.md
@@ -4,23 +4,37 @@
 [![npm](https://badgen.net/npm/v/@contextjs/context?cache=300)](https://www.npmjs.com/package/@contextjs/context)
 [![License](https://badgen.net/static/license/MIT)](https://github.com/contextjs/context/blob/main/LICENSE)
 
-Base ContextJS package containing commands to create, build, watch and debug your projects and solutions.
+> Official CLI for building and managing ContextJS projects.
 
-### Installation
+## ✨ Features
 
+- Unified command-line interface for managing ContextJS-based projects
+- Support for creating new projects from templates
+- Project-wide or selective build and watch support
+- Simple interface with intelligent defaults
+- Works seamlessly with all ContextJS packages
+
+## 📦 Installation
+
+Install globally via npm:
+
+```bash
+npm install -g @contextjs/context
 ```
-npm i -g @contextjs/context
-```
+
+This will expose the `ctx` command globally in your terminal.
+
+## 🚀 Usage
 
 ### Displaying ContextJS options
 
-```shell
+```bash
 ctx
 ```
 
 ### Version
 
-```shell
+```bash
 ctx version
 ```
 
@@ -28,41 +42,63 @@ ctx version
 
 These commands are equivalent:
 
-```shell
+```bash
 ctx new api myApi
 ctx new api -n myApi
 ctx new api --name myApi
 ```
 
-If no argument is passed for api name, current folder name will be used as the api name:
-```shell
+If no argument is passed for API name, current folder name will be used:
+
+```bash
 ctx new api
 ```
 
 If no argument is passed at all, the help will be displayed:
-```shell
+
+```bash
 ctx new
 ```
 
 ### Build
 
-```shell
+Build all detected projects:
+
+```bash
 ctx build
 ```
 
-Pass the name(s) if you want only to build a specific project:
-```shell
+Build specific projects:
+
+```bash
 ctx build myApi1 myApi2 ...
 ```
 
 ### Watch
 
-Watch command is similar to build command with the exception that it watches for the changes and automatically rebuilds the affected projects:
-```shell
+Watch and rebuild all projects on file changes:
+
+```bash
 ctx watch
 ```
 
 Watch specific projects:
-```shell
+
+```bash
 ctx watch myApi1 myApi2 ...
 ```
+
+## 📁 Project Structure
+
+When you create a new project (e.g., `ctx new api myApi`), ContextJS generates:
+
+```
+myApi/
+├── context.ctxp
+├── tsconfig.json
+├── package.json
+└── src/
+    └── main.ts
+```
+
+Each file is preconfigured to follow ContextJS conventions and integrate with the rest of the ecosystem.

--- a/src/context/package.json
+++ b/src/context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contextjs/context",
   "version": "__VERSION__",
-  "description": "ContextJS",
+  "description": "ContextJS - Command-line interface for building and managing ContextJS applications.",
   "author": "ContextJS",
   "license": "MIT",
   "type": "module",
@@ -13,8 +13,17 @@
     "url": "git+https://github.com/contextjs/context.git",
     "directory": "src/context"
   },
+  "keywords": [
+    "contextjs",
+    "cli",
+    "build",
+    "typescript",
+    "compiler",
+    "context"
+  ],
   "peerDependencies": {
     "@contextjs/system": "__VERSION__",
-    "@contextjs/io": "__VERSION__"
+    "@contextjs/io": "__VERSION__",
+    "@contextjs/compiler": "__VERSION__"
   }
 }

--- a/src/context/scripts/after-build.ts
+++ b/src/context/scripts/after-build.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import Script from '../../../scripts/script.ts';
+
+export class AfterBuild extends Script {
+    private readonly contextTransformersPath = 'src/context/src/transformers';
+
+    public override async runAsync(): Promise<void> {
+        this.removeDirectoryAsync(this.contextTransformersPath);
+    }
+}
+
+await new AfterBuild().runAsync();

--- a/src/context/src/extensions/extensions-registrar.ts
+++ b/src/context/src/extensions/extensions-registrar.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import { Compiler, ICompilerExtension } from "@contextjs/compiler";
+import { Directory } from "@contextjs/io";
+import { Console } from "@contextjs/system";
+import path from "path";
+import { pathToFileURL } from "url";
+
+export class ExtensionsRegistrar {
+    private readonly transformersFolder: string;
+    private static registered = false;
+
+    public constructor(transformersFolder?: string) {
+        this.transformersFolder = transformersFolder ??
+            path.join(import.meta.dirname, "../transformers");
+    }
+
+    public async registerAsync(): Promise<void> {
+        if (ExtensionsRegistrar.registered)
+            return;
+
+        ExtensionsRegistrar.registered = true;
+
+        if (!Directory.exists(this.transformersFolder))
+            return;
+
+        const files = Directory
+            .listFiles(this.transformersFolder)
+            .filter(file => file.endsWith(".js"))
+            .sort();
+
+        for (const file of files)
+            await this.loadExtensionAsync(file);
+    }
+
+    private async loadExtensionAsync(filePath: string): Promise<void> {
+        try {
+            const module = await import(pathToFileURL(filePath).href);
+            const extension = module.default as ICompilerExtension;
+
+            if (!extension?.name || typeof extension.getTransformers !== "function")
+                return;
+
+            Compiler.registerExtension(extension);
+        }
+        catch {
+            Console.writeLineError(`Failed to load transformer: ${filePath}`);
+        }
+    }
+}

--- a/src/context/src/models/command-aliases.ts
+++ b/src/context/src/models/command-aliases.ts
@@ -6,9 +6,10 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
-export class Project {
-    public constructor(
-        public readonly name: string,
-        public readonly path: string
-    ) { }
-}
+export const CommandAliases: Record<string, string> = {
+    "-n": "new",
+    "-b": "build",
+    "-r": "restore",
+    "-w": "watch",
+    "-v": "version"
+};

--- a/src/context/src/models/command-type-extensions.ts
+++ b/src/context/src/models/command-type-extensions.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import { CommandAliases } from "./command-aliases.js";
+import { CommandType } from "./command-type.js";
+
+const commandMap: Record<string, CommandType> = {
+    ctx: CommandType.Ctx,
+    new: CommandType.New,
+    build: CommandType.Build,
+    restore: CommandType.Restore,
+    watch: CommandType.Watch,
+    version: CommandType.Version
+};
+
+export class CommandTypeExtensions {
+    public static fromString(value: string): CommandType | null {
+        const lower = value.toLowerCase();
+        const resolved = CommandAliases[lower] ?? lower;
+        return commandMap[resolved] ?? null;
+    }
+}

--- a/src/context/src/models/command-type.ts
+++ b/src/context/src/models/command-type.ts
@@ -14,24 +14,3 @@ export enum CommandType {
     Watch,
     Version
 }
-
-export class CommandTypeExtensions {
-    public static fromString(command: string): CommandType | null {
-        switch (command.toLowerCase()) {
-            case "ctx":
-                return CommandType.Ctx;
-            case "new":
-                return CommandType.New;
-            case "build":
-                return CommandType.Build;
-            case "restore":
-                return CommandType.Restore;
-            case "watch":
-                return CommandType.Watch;
-            case "version":
-                return CommandType.Version;
-            default:
-                return null;
-        }
-    }
-}

--- a/src/context/src/models/command.ts
+++ b/src/context/src/models/command.ts
@@ -10,13 +10,8 @@ import { ConsoleArgument } from "@contextjs/system";
 import { CommandType } from "./command-type.js";
 
 export class Command {
-    public readonly type: CommandType;
-    public readonly args: ConsoleArgument[];
-
-    constructor(
-        type: CommandType,
-        args: ConsoleArgument[]) {
-        this.type = type;
-        this.args = args;
-    }
+    public constructor(
+        public readonly type: CommandType,
+        public readonly args: ConsoleArgument[]
+    ) { }
 }

--- a/src/context/src/models/file-template.ts
+++ b/src/context/src/models/file-template.ts
@@ -7,11 +7,8 @@
  */
 
 export class FileTemplate {
-    public readonly name: string;
-    public content: string | null;
-
-    constructor(name: string, content: string | null = null) {
-        this.name = name;
-        this.content = content;
-    }
+    public constructor(
+        public readonly name: string,
+        public content: string | null = null
+    ) { }
 }

--- a/src/context/src/services/commands/command-base.ts
+++ b/src/context/src/services/commands/command-base.ts
@@ -17,7 +17,7 @@ import { TemplatesService } from "../templates/templates.service.js";
 export abstract class CommandBase {
     public abstract runAsync(command: Command): Promise<void>;
 
-    protected async checkForHelpCommandAsync(command: Command, templatesService: TemplatesService): Promise<boolean> {
+    protected async tryDisplayHelpAsync(command: Command, templatesService: TemplatesService): Promise<boolean> {
         const helpCommandName = command.args[1]?.name;
         if (helpCommandName === '-h' || helpCommandName === '--help') {
             await templatesService.displayHelpAsync();

--- a/src/context/src/services/commands/commands.service.ts
+++ b/src/context/src/services/commands/commands.service.ts
@@ -7,7 +7,8 @@
  */
 
 import { Console, ObjectExtensions } from "@contextjs/system";
-import { CommandType, CommandTypeExtensions } from "../../models/command-type.js";
+import { CommandTypeExtensions } from "../../models/command-type-extensions.js";
+import { CommandType } from "../../models/command-type.js";
 import { Command } from "../../models/command.js";
 
 export class CommandsService {

--- a/src/context/src/services/commands/new.command.ts
+++ b/src/context/src/services/commands/new.command.ts
@@ -6,8 +6,8 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
-import { Console, ObjectExtensions, ProjectTypeExtensions, StringExtensions, VersionService } from "@contextjs/system";
 import { Directory, File, Path } from "@contextjs/io";
+import { Console, ObjectExtensions, ProjectTypeExtensions, StringExtensions, VersionService } from "@contextjs/system";
 import childProcess from "child_process";
 import path from "path";
 import { Command } from "../../models/command.js";
@@ -42,7 +42,7 @@ api             Web API project         A Web API project containing controllers
             return process.exit(1);
         }
 
-        if (await this.checkForHelpCommandAsync(command, templatesService!))
+        if (await this.tryDisplayHelpAsync(command, templatesService!))
             return;
 
         const name = await this.getNameAsync(command);

--- a/src/context/src/services/commands/transformers/transformers.service.ts
+++ b/src/context/src/services/commands/transformers/transformers.service.ts
@@ -1,5 +1,0 @@
-import typescript from "typescript";
-export class TransformersService {
-    public transformers: Array<typescript.TransformerFactory<typescript.SourceFile>> = [];
-    public constructor(private readonly program: typescript.Program) {}
-}

--- a/src/context/src/services/commands/watch.command.ts
+++ b/src/context/src/services/commands/watch.command.ts
@@ -6,82 +6,32 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
+import { Compiler } from "@contextjs/compiler";
 import { Console } from "@contextjs/system";
-import typescript from "typescript";
+import { ExtensionsRegistrar } from "../../extensions/extensions-registrar.js";
 import { Command } from "../../models/command.js";
 import { Project } from "../../models/project.js";
-import { TransformersService } from "./transformers/transformers.service.js";
 import { CommandBase } from "./command-base.js";
 
 export class WatchCommand extends CommandBase {
     public async runAsync(command: Command): Promise<void> {
-        const projectCommand = command.args.find(arg => arg.name === 'project' || arg.name === 'p');
-        const projectDescriptors = this.getProjects(projectCommand?.values || []);
+        const projectCommand = command.args.find(arg => arg.name === "project" || arg.name === "-p");
+        const projects = this.getProjects(projectCommand?.values || []);
 
-        if (projectDescriptors.length === 0) {
-            Console.writeLineError('No projects found. Exiting...');
+        if (projects.length === 0) {
+            Console.writeLineError("No projects found. Exiting...");
             return process.exit(1);
         }
 
-        projectDescriptors.forEach(projectDescriptor => {
-            this.watchProject(projectDescriptor);
-        });
+        await new ExtensionsRegistrar().registerAsync();
+        await Promise.all(projects.map(project => this.watchAsync(project)));
     }
 
-    private watchProject(project: Project) {
-        const configPath = typescript.findConfigFile(project.path, typescript.sys.fileExists, "tsconfig.json");
-        if (!configPath) {
-            Console.writeLineError(`Could not find a valid 'tsconfig.json' in project "${project.name}".`);
-            return process.exit(1);
-        }
-
+    private async watchAsync(project: Project): Promise<void> {
         Console.writeLineInfo(`Watching project "${project.name}" for changes...`);
 
-        const createProgram = typescript.createSemanticDiagnosticsBuilderProgram;
-        const host = typescript.createWatchCompilerHost(
-            configPath,
-            undefined,
-            typescript.sys,
-            createProgram,
-            (diagnostic) => this.processDiagnostics(project, [diagnostic]),
-            (diagnostic) => this.processDiagnostics(project, [diagnostic])
-        );
-
-        const originalCreateProgram = host.createProgram;
-        host.createProgram = ((
-            rootNames: ReadonlyArray<string>,
-            options: typescript.CompilerOptions,
-            host: typescript.CompilerHost,
-            oldProgram: typescript.SemanticDiagnosticsBuilderProgram) => {
-            return originalCreateProgram(rootNames, options, host, oldProgram);
-        }) as typescript.CreateProgram<typescript.SemanticDiagnosticsBuilderProgram>;
-
-        const originalAfterProgramCreate = host.afterProgramCreate;
-        host.afterProgramCreate = builder => {
-            const transformersService = new TransformersService(builder.getProgram()).transformers;
-            const originalEmit = builder.emit;
-            builder.emit = (
-                targetSourceFile,
-                writeFile,
-                cancellationToken,
-                emitOnlyDtsFiles,
-                customTransformers) => {
-                return originalEmit(
-                    targetSourceFile,
-                    writeFile,
-                    cancellationToken,
-                    emitOnlyDtsFiles,
-                    {
-                        before: [...transformersService],
-                        after: customTransformers?.after,
-                        afterDeclarations: customTransformers?.afterDeclarations
-                    }
-                );
-            };
-            originalAfterProgramCreate?.(builder);
-        };
-
-
-        return typescript.createWatchProgram(host);
+        Compiler.watch(project.path, {
+            onDiagnostic: diagnostic => this.processDiagnostics(project, [diagnostic])
+        });
     }
 }

--- a/src/context/tests/extensions/extensions-registrar.test.ts
+++ b/src/context/tests/extensions/extensions-registrar.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import { Compiler } from "@contextjs/compiler";
+import { Directory, File } from "@contextjs/io";
+import { Console } from "@contextjs/system";
+import test, { TestContext } from "node:test";
+import os from "os";
+import path from "path";
+import { ExtensionsRegistrar } from "../../src/extensions/extensions-registrar.js";
+
+function createTempDir(subdir: string): string {
+    const dir = path.join(os.tmpdir(), `ctx-transformers-${subdir}-${Date.now()}`);
+    Directory.create(dir);
+    return dir;
+}
+
+test("ExtensionsRegistrar: registerAsync() loads valid transformers", async (context: TestContext) => {
+    const tempDir = createTempDir("valid");
+    context.after(() => Directory.delete(tempDir));
+
+    File.save(path.join(tempDir, "valid-transformer.js"), `
+        export default {
+            name: 'test-transformer',
+            getTransformers: () => ({ before: null, after: null })
+        };
+    `);
+
+    const registered: string[] = [];
+    const originalRegister = Compiler.registerExtension;
+    Compiler.registerExtension = (ext) => registered.push(ext.name);
+
+    (ExtensionsRegistrar as any).registered = false;
+    const registrar = new ExtensionsRegistrar(tempDir);
+    await registrar.registerAsync();
+
+    context.assert.deepEqual(registered, ["test-transformer"]);
+    Compiler.registerExtension = originalRegister;
+});
+
+test("ExtensionsRegistrar: skips files that do not export valid extensions", async (context: TestContext) => {
+    const tempDir = createTempDir("invalid");
+    context.after(() => Directory.delete(tempDir));
+
+    File.save(path.join(tempDir, "invalid.js"), `export default {}`); // no name/getTransformers
+
+    const registered: string[] = [];
+    const originalRegister = Compiler.registerExtension;
+    Compiler.registerExtension = (ext) => registered.push(ext.name);
+
+    (ExtensionsRegistrar as any).registered = false;
+    const registrar = new ExtensionsRegistrar(tempDir);
+    await registrar.registerAsync();
+
+    context.assert.strictEqual(registered.length, 0);
+    Compiler.registerExtension = originalRegister;
+});
+
+test("ExtensionsRegistrar: handles import errors gracefully", async (context: TestContext) => {
+    const tempDir = createTempDir("broken");
+    context.after(() => Directory.delete(tempDir));
+
+    File.save(path.join(tempDir, "broken.js"), `throw new Error("broken")`);
+
+    let errorLogged = false;
+    const originalError = Console.writeLineError;
+    Console.writeLineError = (text: string) => {
+        if (text.includes("Failed to load transformer"))
+            errorLogged = true;
+    };
+
+    (ExtensionsRegistrar as any).registered = false;
+    const registrar = new ExtensionsRegistrar(tempDir);
+    await registrar.registerAsync();
+
+    context.assert.ok(errorLogged);
+    Console.writeLineError = originalError;
+});
+
+test("ExtensionsRegistrar: loads files in sorted order", async (context: TestContext) => {
+    const tempDir = createTempDir("sorted");
+    context.after(() => Directory.delete(tempDir));
+
+    File.save(path.join(tempDir, "b-transformer.js"), `
+        export default {
+            name: 'B',
+            getTransformers: () => ({ before: null, after: null })
+        };
+    `);
+    File.save(path.join(tempDir, "a-transformer.js"), `
+        export default {
+            name: 'A',
+            getTransformers: () => ({ before: null, after: null })
+        };
+    `);
+
+    const registered: string[] = [];
+    const originalRegister = Compiler.registerExtension;
+    Compiler.registerExtension = (ext) => registered.push(ext.name);
+
+    (ExtensionsRegistrar as any).registered = false;
+    const registrar = new ExtensionsRegistrar(tempDir);
+    await registrar.registerAsync();
+
+    context.assert.deepEqual(registered, ["A", "B"]);
+    Compiler.registerExtension = originalRegister;
+});

--- a/src/context/tests/models/command-aliases.test.ts
+++ b/src/context/tests/models/command-aliases.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import test, { TestContext } from "node:test";
+import { CommandAliases } from "../../src/models/command-aliases.js";
+
+test("CommandAliases: contains all expected aliases", (context: TestContext) => {
+    context.assert.equal(CommandAliases["-n"], "new");
+    context.assert.equal(CommandAliases["-b"], "build");
+    context.assert.equal(CommandAliases["-r"], "restore");
+    context.assert.equal(CommandAliases["-w"], "watch");
+    context.assert.equal(CommandAliases["-v"], "version");
+});
+
+test("CommandAliases: returns undefined for unknown alias", (context: TestContext) => {
+    context.assert.equal(CommandAliases["--bad"], undefined);
+    context.assert.equal(CommandAliases[""], undefined);
+});

--- a/src/context/tests/models/command-type-extensions.test.ts
+++ b/src/context/tests/models/command-type-extensions.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import test, { TestContext } from "node:test";
+import { CommandTypeExtensions } from "../../src/models/command-type-extensions.js";
+import { CommandType } from "../../src/models/command-type.js";
+
+test("CommandTypeExtensions: fromString() - returns correct CommandType for full command", (context: TestContext) => {
+    context.assert.equal(CommandTypeExtensions.fromString("ctx"), CommandType.Ctx);
+    context.assert.equal(CommandTypeExtensions.fromString("new"), CommandType.New);
+    context.assert.equal(CommandTypeExtensions.fromString("build"), CommandType.Build);
+    context.assert.equal(CommandTypeExtensions.fromString("restore"), CommandType.Restore);
+    context.assert.equal(CommandTypeExtensions.fromString("watch"), CommandType.Watch);
+    context.assert.equal(CommandTypeExtensions.fromString("version"), CommandType.Version);
+});
+
+test("CommandTypeExtensions: fromString() - returns correct CommandType for aliases", (context: TestContext) => {
+    context.assert.equal(CommandTypeExtensions.fromString("-n"), CommandType.New);
+    context.assert.equal(CommandTypeExtensions.fromString("-b"), CommandType.Build);
+    context.assert.equal(CommandTypeExtensions.fromString("-r"), CommandType.Restore);
+    context.assert.equal(CommandTypeExtensions.fromString("-w"), CommandType.Watch);
+    context.assert.equal(CommandTypeExtensions.fromString("-v"), CommandType.Version);
+});
+
+test("CommandTypeExtensions: fromString() - returns null for unknown command", (context: TestContext) => {
+    context.assert.equal(CommandTypeExtensions.fromString("unknown"), null);
+    context.assert.equal(CommandTypeExtensions.fromString("--invalid"), null);
+});
+
+test("CommandTypeExtensions: fromString() - handles case-insensitive input", (context: TestContext) => {
+    context.assert.equal(CommandTypeExtensions.fromString("BUILD"), CommandType.Build);
+    context.assert.equal(CommandTypeExtensions.fromString("-N"), CommandType.New);
+});

--- a/src/context/tests/models/command-type.test.ts
+++ b/src/context/tests/models/command-type.test.ts
@@ -6,40 +6,23 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
-import test, { TestContext } from 'node:test';
-import { CommandType, CommandTypeExtensions } from "../../src/models/command-type.ts";
+import test, { TestContext } from "node:test";
+import { CommandType } from "../../src/models/command-type.js";
 
-test('CommandType: length - success', (context: TestContext) => {
-    context.assert.strictEqual(Object.keys(CommandType).length / 2, 6);
+test("CommandType: enum has all expected values", (context: TestContext) => {
+    context.assert.equal(CommandType.Ctx, 0);
+    context.assert.equal(CommandType.New, 1);
+    context.assert.equal(CommandType.Build, 2);
+    context.assert.equal(CommandType.Restore, 3);
+    context.assert.equal(CommandType.Watch, 4);
+    context.assert.equal(CommandType.Version, 5);
 });
 
-test('CommandTypeMethods: fromString - success', (context: TestContext) => {
-
-    let command = 'build';
-    let result = CommandTypeExtensions.fromString(command);
-    context.assert.strictEqual(result, CommandType.Build);
-
-    command = 'restore';
-    result = CommandTypeExtensions.fromString(command);
-    context.assert.strictEqual(result, CommandType.Restore);
-
-    command = 'watch';
-    result = CommandTypeExtensions.fromString(command);
-    context.assert.strictEqual(result, CommandType.Watch);
-
-    command = 'new';
-    result = CommandTypeExtensions.fromString(command);
-    context.assert.strictEqual(result, CommandType.New);
-
-    command = 'version';
-    result = CommandTypeExtensions.fromString(command);
-    context.assert.strictEqual(result, CommandType.Version);
-
-    command = '';
-    result = CommandTypeExtensions.fromString(command);
-    context.assert.strictEqual(result, null);
-
-    command = 'invalid';
-    result = CommandTypeExtensions.fromString(command);
-    context.assert.strictEqual(result, null);
+test("CommandType: enum can map numeric values back to names", (context: TestContext) => {
+    context.assert.equal(CommandType[0], "Ctx");
+    context.assert.equal(CommandType[1], "New");
+    context.assert.equal(CommandType[2], "Build");
+    context.assert.equal(CommandType[3], "Restore");
+    context.assert.equal(CommandType[4], "Watch");
+    context.assert.equal(CommandType[5], "Version");
 });

--- a/src/context/tests/services/commands/ctx.command.test.ts
+++ b/src/context/tests/services/commands/ctx.command.test.ts
@@ -12,7 +12,7 @@ import { CommandType } from "../../../src/models/command-type.ts";
 import { Command } from "../../../src/models/command.ts";
 import { CtxCommand } from "../../../src/services/commands/ctx.command.ts";
 
-test('ContextCommand: runAsync - success', async (context: TestContext) => {
+test('CtxCommand: runAsync - success', async (context: TestContext) => {
     const originalOutput = Console['output'];
     const originalExit = process.exit;
 

--- a/src/context/tests/services/commands/restore.command.test.ts
+++ b/src/context/tests/services/commands/restore.command.test.ts
@@ -6,8 +6,12 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
+import { Directory, File } from "@contextjs/io";
 import { Console, StringExtensions } from "@contextjs/system";
+import childProcess from "node:child_process";
+import os from "node:os";
 import test, { TestContext } from 'node:test';
+import path from "path";
 import { CommandType } from "../../../src/models/command-type.ts";
 import { Command } from "../../../src/models/command.ts";
 import { Project } from "../../../src/models/project.ts";
@@ -108,7 +112,7 @@ test('RestoreCommand: runAsync - success', async (context: TestContext) => {
     context.assert.strictEqual(exitCode, 0);
 });
 
-test('RestoreCommand: restore - success', async (context: TestContext) => {
+test('RestoreCommand: restoreAsync - exits when context.ctxp is missing', async (context: TestContext) => {
     const originalExit = process.exit;
     const originalOutput = Console['output'];
 

--- a/src/context/tests/services/commands/watch.command.test.ts
+++ b/src/context/tests/services/commands/watch.command.test.ts
@@ -6,41 +6,31 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
-import { Console, ConsoleArgument, StringExtensions } from "@contextjs/system";
-import test, { TestContext } from 'node:test';
+import { Console, StringExtensions } from "@contextjs/system";
+import test, { TestContext } from "node:test";
 import { CommandType } from "../../../src/models/command-type.ts";
 import { Command } from "../../../src/models/command.ts";
 import { Project } from "../../../src/models/project.ts";
 import { WatchCommand } from "../../../src/services/commands/watch.command.ts";
 
-test('WatchCommand: runAsync - no projects', async (context: TestContext) => {
-    let processExitCode = -100;
+test("WatchCommand: runAsync - no projects", async (context: TestContext) => {
     let output = StringExtensions.empty;
+    const originalOutput = Console["output"];
     const originalExit = process.exit;
-    const originalOutput = Console['output'];
 
-    Console.setOutput((...args: any[]) => {
-        output += args.map(arg => String(arg)).join(' ') + '\n';
-    });
+    Console.setOutput((...args: any[]) => { output += args.map(arg => String(arg)).join(" ") + "\n"; });
+    process.exit = (code: number) => { throw new Error(`exit:${code}`); };
 
-    process.exit = (code: number) => {
-        processExitCode = code;
-        throw new Error(`exit:${code}`);
-    };
-
-    const consoleArguments: ConsoleArgument[] = [
-        { name: 'project', values: ['test'] }
-    ];
-
-    const command = new Command(CommandType.Watch, consoleArguments);
+    const command = new Command(CommandType.Watch, [{ name: "project", values: ["none"] }]);
     const watchCommand = new WatchCommand();
+    context.mock.method(watchCommand as any, "getProjects", () => []);
 
     let threw: Error | null = null;
     try {
         await watchCommand.runAsync(command);
-    } 
-    catch (err) {
-        threw = err as Error;
+    }
+    catch (error) {
+        threw = error as Error;
     }
 
     context.assert.ok(threw);
@@ -51,46 +41,25 @@ test('WatchCommand: runAsync - no projects', async (context: TestContext) => {
     process.exit = originalExit;
 });
 
-test('WatchCommand: runAsync - success', async (context: TestContext) => {
+test("WatchCommand: runAsync - success", async (context: TestContext) => {
     let output = StringExtensions.empty;
-    const originalOutput = Console['output'];
+    const originalOutput = Console["output"];
     const originalExit = process.exit;
 
-    Console.setOutput((...args: any[]) => {
-        output += args.map(arg => String(arg)).join(' ') + '\n';
-    });
+    Console.setOutput((...args: any[]) => { output += args.map(arg => String(arg)).join(" ") + "\n"; });
+
+    process.exit = (code: number) => { throw new Error(`exit:${code}`); };
 
     const command = new Command(CommandType.Watch, []);
     const watchCommand = new WatchCommand();
-    const projects: Project[] = [new Project('test', 'test')];
+    const projects: Project[] = [new Project("test", "test")];
 
-    context.mock.method(watchCommand as any, 'getProjects', () => projects);
-    context.mock.method(watchCommand as any, 'watchProject', () => {
-        Console.writeLineInfo('Watching project test for changes...');
-    });
+    context.mock.method(watchCommand as any, "getProjects", () => projects);
+
+    const { Compiler } = await import("@contextjs/compiler");
+    context.mock.method(Compiler, "watch", () => { });
 
     await watchCommand.runAsync(command);
-
-    context.assert.match(output, /Watching project test for changes/);
-
-    Console.setOutput(originalOutput);
-    process.exit = originalExit;
-});
-
-test('watchProject_Success', async (context: TestContext) => {
-    let output = '';
-    const watchCommand = new WatchCommand();
-    const originalOutput = Console['output'];
-    const originalExit = process.exit;
-
-    const project: Project = new Project('test', 'src/system');
-
-    Console.setOutput((...args: any[]) => {
-        output += args.map(arg => String(arg)).join(' ') + '\n';
-    });
-
-    const watcher = (watchCommand as any).watchProject(project);
-    watcher?.close();
 
     context.assert.match(output, /Watching project "test" for changes/);
 

--- a/src/context/tests/services/templates/api-template.service.test.ts
+++ b/src/context/tests/services/templates/api-template.service.test.ts
@@ -6,7 +6,7 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
-import { Console } from '@contextjs/system';
+import { Console, StringExtensions } from '@contextjs/system';
 import test, { TestContext } from 'node:test';
 import { APITemplatesService } from '../../../src/services/templates/api-templates.service.js';
 
@@ -17,36 +17,43 @@ Usage: ctx new api [options]
 Options             Description
 ------------        -----------------------------------------------------
 [no option]         Creates a project with current directory name as project name.
--n, --name          The name of the project to create.
-`;
+-n, --name          The name of the project to create.`;
+
+    let output = StringExtensions.empty;
+    let exitCode = -1;
 
     const originalExit = process.exit;
     const originalOutput = Console['output'];
-    let output = '';
-    let exitCode = -1;
-
-    const stripAnsi = (text: string): string => text.replace(/\x1B\[[0-9;]*m/g, '');
 
     Console.setOutput((...args: any[]) => {
-        output += args.map(arg => String(arg)).join(' ') + '\n';
+        output += args.map(String).join(' ') + '\n';
     });
 
     process.exit = (code: number) => {
         exitCode = code;
-        return undefined as never;
+        throw new Error(`exit:${code}`);
     };
+
+    let threw: Error | null = null;
 
     try {
         await new APITemplatesService().displayHelpAsync();
+    } catch (err) {
+        threw = err as Error;
     }
-    catch { }
+
+    const stripAnsi = (text: string): string =>
+        text.replace(/\x1B\[[0-9;]*m/g, '');
 
     const cleanOutput = stripAnsi(output);
-    const helpTextIndex = cleanOutput.indexOf('The "ctx new api" command');
-    const justHelpText = helpTextIndex !== -1 ? cleanOutput.slice(helpTextIndex).trim() : '';
+    const helpTextStart = cleanOutput.indexOf('The "ctx new api" command');
+    const actualHelpText = helpTextStart !== -1
+        ? cleanOutput.slice(helpTextStart).trim()
+        : cleanOutput.trim();
 
-    context.assert.strictEqual(exitCode, 0);
-    context.assert.strictEqual(justHelpText, expectedHelpText.trim());
+    context.assert.ok(threw);
+    context.assert.match(threw.message, /exit:0/);
+    context.assert.strictEqual(actualHelpText, expectedHelpText);
 
     Console.setOutput(originalOutput);
     process.exit = originalExit;

--- a/src/context/tests/services/templates/template-service-resolver.test.ts
+++ b/src/context/tests/services/templates/template-service-resolver.test.ts
@@ -6,22 +6,21 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
-import { ProjectType } from '@contextjs/system';
-import test, { TestContext } from 'node:test';
-import { APITemplatesService } from '../../../src/services/templates/api-templates.service.ts';
-import { TemplatesServiceResolver } from '../../../src/services/templates/templates-service-resolver.ts';
+import { ProjectType } from "@contextjs/system";
+import test, { TestContext } from "node:test";
+import { APITemplatesService } from "../../../src/services/templates/api-templates.service.js";
+import { TemplatesServiceResolver } from "../../../src/services/templates/templates-service-resolver.js";
 
-test('TemplateServiceResolver: resolveAsync - success', async (context: TestContext) => {
+test("TemplatesServiceResolver: resolveAsync() returns APITemplatesService for ProjectType.API", async (context: TestContext) => {
+    const service = await TemplatesServiceResolver.resolveAsync(ProjectType.API);
 
-    const projectType = ProjectType.API;
-    const service = await TemplatesServiceResolver.resolveAsync(projectType);
-
-    context.assert.ok(service instanceof APITemplatesService);
-    context.assert.ok(service);
+    context.assert.ok(service, "Expected a TemplatesService instance to be returned");
+    context.assert.ok(service instanceof APITemplatesService, "Expected instance of APITemplatesService");
 });
 
-test('TemplateServiceResolver: resolveAsync - null', async (context: TestContext) => {
-    const service = await TemplatesServiceResolver.resolveAsync(-1);
+test("TemplatesServiceResolver: resolveAsync() returns null for unknown ProjectType", async (context: TestContext) => {
+    const invalidProjectType = -1 as unknown as ProjectType;
+    const service = await TemplatesServiceResolver.resolveAsync(invalidProjectType);
 
-    context.assert.strictEqual(service, null);
+    context.assert.strictEqual(service, null, "Expected null for unknown project type");
 });

--- a/src/context/tests/services/templates/template.service.test.ts
+++ b/src/context/tests/services/templates/template.service.test.ts
@@ -6,28 +6,23 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
-import test, { TestContext } from 'node:test';
-import { FileTemplate } from '../../../src/models/file-template.js';
-import { TemplatesService } from '../../../src/services/templates/templates.service.js';
+import test, { TestContext } from "node:test";
+import { FileTemplate } from "../../../src/models/file-template.js";
+import { TemplatesService } from "../../../src/services/templates/templates.service.js";
 
-test('TemplateService: instance - success', (context: TestContext) => {
+test("TemplatesService: abstract class contract - success", (context: TestContext) => {
     class TestTemplatesService extends TemplatesService {
-        protected helpText: string;
-        public displayHelpAsync(): Promise<void> {
-            throw new Error('Method not implemented.');
-        }
-        public templates: FileTemplate[];
+        protected override readonly helpText = "Help text";
+        public override templates: FileTemplate[] = [{ name: "test", content: "test" }];
 
-        public constructor() {
-            super();
-            this.helpText = 'Help text';
-            this.templates = [{ name: 'test', content: 'test' }];
+        public override async displayHelpAsync(): Promise<void> {
+            throw new Error("Method not implemented.");
         }
     }
 
     const service = new TestTemplatesService();
 
-    context.assert.strictEqual((service as any).helpText, 'Help text');
-    context.assert.throws(() => service.displayHelpAsync(), { message: 'Method not implemented.' });
-    context.assert.deepEqual((service as any).templates, [{ name: 'test', content: 'test' }]);
+    context.assert.strictEqual((service as any).helpText, "Help text");
+    context.assert.deepEqual(service.templates, [{ name: "test", content: "test" }]);
+    context.assert.rejects(() => service.displayHelpAsync(), { message: "Method not implemented." });
 });

--- a/src/context/tests/templates/api/context.ctxp.template.test.ts
+++ b/src/context/tests/templates/api/context.ctxp.template.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import test, { TestContext } from "node:test";
+import { ContextTemplate } from "../../../src/templates/api/context.ctxp.template.js";
+import { FileTemplate } from "../../../src/models/file-template.js";
+
+test("ContextTemplate: template definition - success", (context: TestContext) => {
+    const template = ContextTemplate.template;
+
+    context.assert.ok(template instanceof FileTemplate);
+    context.assert.strictEqual(template.name, "context.ctxp");
+    context.assert.match(template.content!, /"name": "{{name}}"/);
+    context.assert.match(template.content!, /"main": "src\/main.ts"/);
+});

--- a/src/context/tests/templates/api/main.ts.template.test.ts
+++ b/src/context/tests/templates/api/main.ts.template.test.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import test, { TestContext } from "node:test";
+import { FileTemplate } from "../../../src/models/file-template.js";
+import { MainTemplate } from "../../../src/templates/api/main.ts.template.js";
+
+test("MainTemplate: template definition - success", (context: TestContext) => {
+    const template = MainTemplate.template;
+
+    context.assert.ok(template instanceof FileTemplate);
+    context.assert.strictEqual(template.name, "src/main.ts");
+    context.assert.match(template.content!, /Application/);
+    context.assert.match(template.content!, /application\.onRun\(/);
+    context.assert.match(template.content!, /application\.runAsync\(\);/);
+});

--- a/src/context/tests/templates/api/package.json.template.test.ts
+++ b/src/context/tests/templates/api/package.json.template.test.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import { VersionService } from "@contextjs/system";
+import test, { TestContext } from "node:test";
+import { FileTemplate } from "../../../src/models/file-template.js";
+import { PackageTemplate } from "../../../src/templates/api/package.json.template.js";
+
+test("PackageTemplate: template definition - success", (context: TestContext) => {
+    const template = PackageTemplate.template;
+
+    context.assert.ok(template instanceof FileTemplate);
+    context.assert.strictEqual(template.name, "package.json");
+
+    const version = VersionService.get();
+    context.assert.match(template.content!, new RegExp(`"@contextjs/system":\\s*"${version}"`));
+    context.assert.match(template.content!, /"name": "{{name}}"/);
+    context.assert.match(template.content!, /"type": "module"/);
+});

--- a/src/context/tests/templates/tsconfig.json.template.test.ts
+++ b/src/context/tests/templates/tsconfig.json.template.test.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import test, { TestContext } from "node:test";
+import { FileTemplate } from "../../src/models/file-template.js";
+import { TsConfigTemplate } from "../../src/templates/tsconfig.json.template.js";
+
+test("TsConfigTemplate: template definition - success", (context: TestContext) => {
+    const template = TsConfigTemplate.template;
+
+    context.assert.ok(template instanceof FileTemplate);
+    context.assert.strictEqual(template.name, "tsconfig.json");
+    context.assert.match(template.content!, /"outDir": "..\/_build\/{{name}}"/);
+    context.assert.match(template.content!, /"target": "ESNext"/);
+    context.assert.match(template.content!, /"module": "NodeNext"/);
+    context.assert.match(template.content!, /"strict": true/);
+    context.assert.match(template.content!, /"experimentalDecorators": true/);
+    context.assert.match(template.content!, /"emitDecoratorMetadata": true/);
+});


### PR DESCRIPTION
- Updated command type tests to validate enum values and mappings.
- Enhanced build command tests with improved mocking and error handling.
- Added tests for command aliases and command type extensions.
- Introduced extensions registrar for dynamic transformer loading.
- Created templates for API and TypeScript configuration with corresponding tests.
- Implemented after-build script for cleaning up transformers directory.

Closes #121