### PR TITLE
feat(exceptions): add new exception classes for argument validation and expression errors

### DIFF
--- a/src/system/README.md
+++ b/src/system/README.md
@@ -4,29 +4,24 @@
 [![npm](https://badgen.net/npm/v/@contextjs/system?cache=300)](https://www.npmjs.com/package/@contextjs/system)
 [![License](https://badgen.net/static/license/MIT)](https://github.com/contextjs/context/blob/main/LICENSE)
 
-> A zero-dependency system utility library for the ContextJS ecosystem, providing application lifecycle, environment detection, console formatting, exception handling, and core extensions — all written with full type safety.
-
----
+> A zero-dependency system utility library for the ContextJS ecosystem, providing application lifecycle, environment detection, console formatting, exception handling, property extraction (`nameof()`), and core extensions — all written with full type safety.
 
 ## ✨ Features
 
 - **Application lifecycle management** with `onRun()` hooks
 - **Environment detection** with development/production/test/staging support
 - **Console formatting** with ANSI styles and argument parsing
-- **Typed exceptions** like `NullReferenceException`
+- **Typed exceptions** like `NullReferenceException` and `InvalidExpressionException`
+- **Safe property extraction** via `nameof()` for both lambdas and keys
 - **Core helpers** for object and string manipulation with type guards
 - **Type-safe utility `Throw` guard methods**
 - **Fully tested**, 100% coverage, no dependencies
-
----
 
 ## 📆 Installation
 
 ```bash
 npm i @contextjs/system
 ```
-
----
 
 ## 🚀 Quick Start
 
@@ -57,7 +52,14 @@ Run with:
 node app.js --environment production
 ```
 
----
+## 🔍 nameof() Example
+
+```ts
+const property = nameof(() => user.name); // "name"
+const key = nameof<Config>('port');       // "port"
+```
+
+Throws `InvalidExpressionException` if the lambda is not a valid property accessor.
 
 ## 🎨 Console Formatting
 
@@ -69,8 +71,6 @@ Console.writeLineInfo('ℹ Info');
 
 Console.writeLineFormatted({ format: ['bold', 'green'], text: 'Styled' });
 ```
-
----
 
 ## 📚 Common Utilities
 
@@ -97,8 +97,6 @@ if (!ObjectExtensions.isNullOrUndefined(value)) {
 }
 ```
 
----
-
 ## 🧪 Testing
 
 This library is fully covered with unit tests using Node's native `test` module.
@@ -107,11 +105,10 @@ Test coverage includes:
 - Environment parsing
 - Console formatting
 - String/object helpers
-- Throw guard behavior
+- Exception and guard behavior
 - Version display
 - Application lifecycle execution
-
----
+- Property name extraction via `nameof()`
 
 ## 💡 Philosophy
 
@@ -187,6 +184,11 @@ export declare class StringExtensions {
      * Represents an empty string.
      */
     public static readonly empty: string;
+
+    /**
+     * Represents a new line, platform-specific.
+     */
+    public static readonly newLine: string;
 
     /**
      * Checks if the given string is null or empty.
@@ -499,25 +501,101 @@ export declare class VersionService {
      */
     public static get(): string;
 }
+
+/**
+ * Returns the name of a property as a string.
+ *
+ * This utility supports two forms:
+ * - Passing a string literal that matches a key of the specified type.
+ * - Passing a lambda expression that accesses a property.
+ *
+ * @example
+ * nameof<Person>("firstName");               // "firstName"
+ * nameof(() => person.age);                  // "age"
+ *
+ * @template T The target type whose key or property is being referenced.
+ * @param expr A string literal of a key in type T, or a lambda accessing a property.
+ * @returns The extracted property name.
+ * @throws {InvalidExpressionException} If the lambda expression is invalid or cannot be parsed.
+ */
+export declare function nameof<T>(expr: keyof T): string;
+export declare function nameof<T>(expr: () => T): string;
+export declare function nameof<T>(expr: keyof T | (() => T)): string;
 ```
 
 ### Exceptions
 
 ```typescript
 /**
- * Represents an exception with a custom message.
+ * Represents a general-purpose application exception.
  */
 export declare class Exception extends Error {
     /**
-     * Creates an instance of Exception.
-     * @param {string} message - The error message.
+     * Initializes a new instance of the Exception class.
+     * @param message The error message.
+     * @param options Optional error options.
      */
-    constructor(message: string);
+    constructor(message: string, options?: ErrorOptions);
 }
 
+/**
+ * Represents a generic system-level exception.
+ */
+export declare class SystemException extends Exception {
+    /**
+     * Initializes a new instance of the SystemException class.
+     * @param message The error message.
+     * @param options Optional error options.
+     */
+    constructor(message?: string, options?: ErrorOptions);
+}
 
 /**
- * Represents an exception that occurs when a null reference is encountered.
+ * Represents an exception thrown when an argument is invalid.
  */
-export declare class NullReferenceException extends Exception { }
+export declare class ArgumentException extends SystemException {
+    /**
+     * Initializes a new instance of the ArgumentException class.
+     * @param message The error message.
+     * @param options Optional error options.
+     */
+    constructor(message?: string, options?: ErrorOptions);
+}
+
+/**
+ * Represents an exception thrown when an argument is out of range.
+ */
+export declare class ArgumentOutOfRangeException extends ArgumentException {
+    /**
+     * Initializes a new instance of the ArgumentOutOfRangeException class.
+     * @param message The error message.
+     * @param options Optional error options.
+     */
+    constructor(message?: string, options?: ErrorOptions);
+}
+
+/**
+ * Represents an exception thrown when a null value is encountered unexpectedly.
+ */
+export declare class NullReferenceException extends Exception {
+    /**
+     * Initializes a new instance of the NullReferenceException class.
+     * @param message The error message.
+     * @param options Optional error options.
+     */
+    constructor(message?: string, options?: ErrorOptions);
+}
+
+/**
+ * Represents an exception thrown when a provided expression is not valid for extraction.
+ */
+export declare class InvalidExpressionException extends SystemException {
+    /**
+     * Creates a new instance of the InvalidExpressionException class.
+     *
+     * @param message The error message that explains the reason for the exception.
+     * @param options Optional error options.
+     */
+    constructor(message: string, options?: ErrorOptions);
+}
 ```

--- a/src/system/src/api/index.d.ts
+++ b/src/system/src/api/index.d.ts
@@ -41,21 +41,77 @@ export declare class Application {
 //#region Exceptions
 
 /**
- * Represents an exception with a custom message.
+ * Represents a general-purpose application exception.
  */
 export declare class Exception extends Error {
     /**
-     * Creates an instance of Exception.
-     * @param {string} message - The error message.
+     * Initializes a new instance of the Exception class.
+     * @param message The error message.
+     * @param options Optional error options.
      */
-    constructor(message: string);
+    constructor(message: string, options?: ErrorOptions);
 }
 
+/**
+ * Represents a generic system-level exception.
+ */
+export declare class SystemException extends Exception {
+    /**
+     * Initializes a new instance of the SystemException class.
+     * @param message The error message.
+     * @param options Optional error options.
+     */
+    constructor(message?: string, options?: ErrorOptions);
+}
 
 /**
- * Represents an exception that occurs when a null reference is encountered.
+ * Represents an exception thrown when an argument is invalid.
  */
-export declare class NullReferenceException extends Exception { }
+export declare class ArgumentException extends SystemException {
+    /**
+     * Initializes a new instance of the ArgumentException class.
+     * @param message The error message.
+     * @param options Optional error options.
+     */
+    constructor(message?: string, options?: ErrorOptions);
+}
+
+/**
+ * Represents an exception thrown when an argument is out of range.
+ */
+export declare class ArgumentOutOfRangeException extends ArgumentException {
+    /**
+     * Initializes a new instance of the ArgumentOutOfRangeException class.
+     * @param message The error message.
+     * @param options Optional error options.
+     */
+    constructor(message?: string, options?: ErrorOptions);
+}
+
+/**
+ * Represents an exception thrown when a null value is encountered unexpectedly.
+ */
+export declare class NullReferenceException extends Exception {
+    /**
+     * Initializes a new instance of the NullReferenceException class.
+     * @param message The error message.
+     * @param options Optional error options.
+     */
+    constructor(message?: string, options?: ErrorOptions);
+}
+
+/**
+ * Represents an exception thrown when a provided expression is not valid for extraction.
+ */
+export declare class InvalidExpressionException extends SystemException {
+    /**
+     * Creates a new instance of the InvalidExpressionException class.
+     *
+     * @param message The error message that explains the reason for the exception.
+     * @param options Optional error options.
+     */
+    constructor(message: string, options?: ErrorOptions);
+}
 
 //#endregion
 
@@ -95,6 +151,11 @@ export declare class StringExtensions {
      * Represents an empty string.
      */
     public static readonly empty: string;
+
+    /**
+     * Represents a new line, platform-specific.
+     */
+    public static readonly newLine: string;
 
     /**
      * Checks if the given string is null or empty.
@@ -470,5 +531,25 @@ export declare class VersionService {
      */
     public static get(): string;
 }
+
+/**
+ * Returns the name of a property as a string.
+ *
+ * This utility supports two forms:
+ * - Passing a string literal that matches a key of the specified type.
+ * - Passing a lambda expression that accesses a property.
+ *
+ * @example
+ * nameof<Person>("firstName");               // "firstName"
+ * nameof(() => person.age);                  // "age"
+ *
+ * @template T The target type whose key or property is being referenced.
+ * @param expr A string literal of a key in type T, or a lambda accessing a property.
+ * @returns The extracted property name.
+ * @throws {InvalidExpressionException} If the lambda expression is invalid or cannot be parsed.
+ */
+export declare function nameof<T>(expr: keyof T): string;
+export declare function nameof<T>(expr: () => T): string;
+export declare function nameof<T>(expr: keyof T | (() => T)): string;
 
 //#endregion

--- a/src/system/src/api/index.ts
+++ b/src/system/src/api/index.ts
@@ -8,8 +8,12 @@
 
 export * from "../application.js";
 
+export * from "../exceptions/argument-out-of-range.exception.js";
+export * from "../exceptions/argument.exception.js";
 export * from "../exceptions/exception.js";
+export * from "../exceptions/invalid-expression.exception.js";
 export * from "../exceptions/null-reference.exception.js";
+export * from "../exceptions/system.exception.js";
 
 export * from "../extensions/object.extensions.js";
 export * from "../extensions/string.extensions.js";
@@ -21,5 +25,6 @@ export * from "../models/environment.js";
 export * from "../models/project-type.js";
 
 export * from "../services/console.js";
+export * from "../services/nameof.js";
 export * from "../services/throw.service.js";
 export * from "../services/version.service.js";

--- a/src/system/src/exceptions/argument-out-of-range.exception.ts
+++ b/src/system/src/exceptions/argument-out-of-range.exception.ts
@@ -6,11 +6,11 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
-import { SystemException } from "./system.exception.js";
+import { ArgumentException } from "./argument.exception.js";
 
-export class NullReferenceException extends SystemException {
+export class ArgumentOutOfRangeException extends ArgumentException {
     public constructor(message?: string, options?: ErrorOptions) {
-        super(message ?? "The specified reference is null or undefined.", options);
-        this.name = NullReferenceException.name;
+        super(message ?? "The specified argument is out of range.", options);
+        this.name = ArgumentOutOfRangeException.name;
     }
 }

--- a/src/system/src/exceptions/argument.exception.ts
+++ b/src/system/src/exceptions/argument.exception.ts
@@ -8,9 +8,9 @@
 
 import { SystemException } from "./system.exception.js";
 
-export class NullReferenceException extends SystemException {
+export class ArgumentException extends SystemException {
     public constructor(message?: string, options?: ErrorOptions) {
-        super(message ?? "The specified reference is null or undefined.", options);
-        this.name = NullReferenceException.name;
+        super(message ?? "The specified argument is invalid.", options);
+        this.name = ArgumentException.name;
     }
 }

--- a/src/system/src/exceptions/invalid-expression.exception.ts
+++ b/src/system/src/exceptions/invalid-expression.exception.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import { SystemException } from "./system.exception.js";
+
+/**
+ * Represents an exception thrown when a provided expression is not valid for extraction.
+ */
+export class InvalidExpressionException extends SystemException {
+    /**
+     * Creates a new instance of the InvalidExpressionException class.
+     *
+     * @param message The error message that explains the reason for the exception.
+     * @param options Optional error options.
+     */
+    constructor(message: string, options?: ErrorOptions) {
+        super(message, options);
+        this.name = "InvalidExpressionException";
+    }
+}

--- a/src/system/src/exceptions/system.exception.ts
+++ b/src/system/src/exceptions/system.exception.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import { Exception } from "./exception.js";
+
+export class SystemException extends Exception {
+    constructor(message?: string, options?: ErrorOptions) {
+        super(message ?? "A system error has occurred.", options);
+        this.name = SystemException.name;
+    }
+}

--- a/src/system/src/extensions/string.extensions.ts
+++ b/src/system/src/extensions/string.extensions.ts
@@ -6,10 +6,13 @@
  * found at https://github.com/contextjs/context/blob/main/LICENSE
  */
 
+import os from "node:os";
+
 export class StringExtensions {
     private static readonly lineBreaks = ['\r', '\n', '\u0085', '\u2028', '\u2029'];
 
     public static readonly empty: string = "";
+    public static readonly newLine: string = os.EOL;
 
     public static isNullOrEmpty(value: string | null | undefined): value is null | undefined | "" {
         return value === null || value === undefined || value === StringExtensions.empty;

--- a/src/system/src/services/nameof.ts
+++ b/src/system/src/services/nameof.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import { InvalidExpressionException } from "../exceptions/invalid-expression.exception.js";
+
+/**
+ * Returns the name of a property as a string.
+ *
+ * This utility supports two forms:
+ * - Passing a string literal that matches a key of the specified type.
+ * - Passing a lambda expression that accesses a property.
+ *
+ * @example
+ * nameof<Person>("firstName");               // "firstName"
+ * nameof(() => person.age);                  // "age"
+ *
+ * @template T The target type whose key or property is being referenced.
+ * @param expr A string literal of a key in type T, or a lambda accessing a property.
+ * @returns The extracted property name.
+ * @throws {InvalidExpressionException} If the lambda expression is invalid or cannot be parsed.
+ */
+export function nameof<T>(expr: keyof T): string;
+export function nameof<T>(expr: () => T): string;
+export function nameof<T>(expr: keyof T | (() => T)): string {
+    if (typeof expr === "string")
+        return expr;
+
+    const match = /\.\s*([_$a-zA-Z][_$a-zA-Z0-9]*)\s*$/.exec(expr.toString());
+    if (!match)
+        throw new InvalidExpressionException(`Invalid expression passed to nameof(): ${expr.toString()}`);
+
+    return match[1];
+}

--- a/src/system/tests/services/nameof.test.ts
+++ b/src/system/tests/services/nameof.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright ContextJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found at https://github.com/contextjs/context/blob/main/LICENSE
+ */
+
+import test, { TestContext } from "node:test";
+import { InvalidExpressionException } from "../../src/exceptions/invalid-expression.exception.js";
+import { nameof } from "../../src/services/nameof.js";
+
+interface Sample { firstName: string; age: number; }
+
+test("nameof: returns key from string literal", (context: TestContext) => {
+    context.assert.strictEqual(nameof<Sample>("firstName"), "firstName");
+    context.assert.strictEqual(nameof<Sample>("age"), "age");
+});
+
+test("nameof: extracts property name from lambda", (context: TestContext) => {
+    const sample: Sample = { firstName: "John", age: 42 };
+    context.assert.strictEqual(nameof(() => sample.firstName), "firstName");
+    context.assert.strictEqual(nameof(() => sample.age), "age");
+});
+
+test("nameof: throws on invalid expression", (context: TestContext) => {
+    context.assert.throws(() => nameof(() => 123), InvalidExpressionException);
+    context.assert.throws(() => nameof(() => null), InvalidExpressionException);
+});


### PR DESCRIPTION
- Introduced `ArgumentException` and `ArgumentOutOfRangeException` for better argument handling.
- Added `InvalidExpressionException` for invalid property access expressions.
- Updated existing exceptions to extend from the new classes.
- Enhanced README and documentation for clarity on new features.
- Implemented `nameof` utility function for property name extraction with tests.

Closes #142